### PR TITLE
fix spec to work with oapi-codegen

### DIFF
--- a/SampleCode/RestApi/Clients/Go/api/swagger.yaml
+++ b/SampleCode/RestApi/Clients/Go/api/swagger.yaml
@@ -18204,7 +18204,7 @@ paths:
       - apikeyauth: []
       - embyauth: []
       x-RequiredAuthentication: Requires authentication as user
-  /Items/{Id}/Images/{Type}/{Index}/{Tag}/{Format}/{MaxWidth}/{MaxHeight}/{PercentPlayed}/{UnplayedCount}:
+  /Items/{Id}/Images/{Type}/{Index}/{Tag}/{Format}/{MaxWidth}/{MaxHeight}/{PercentPlayed}/{UnPlayedCount}:
     get:
       tags:
       - ImageService
@@ -79534,9 +79534,9 @@ components:
       - wmv1
       - wmv2
       - wmv3
-      - _012v
-      - _4xm
-      - _8bps
+      - "012v"
+      - "4xm"
+      - "8bps"
       - a64_multi
       - a64_multi5
       - aasc
@@ -79863,9 +79863,9 @@ components:
       - mmal
       - d3d11va_vld
       - cuda
-      - _0rgb
+      - "0rgb"
       - rgb0
-      - _0bgr
+      - "0bgr"
       - bgr0
       - yuv420p12
       - yuv420p14


### PR DESCRIPTION
This PR updates some errors in the spec file, which then allows the spec file to be used by the [oapi-codegen](https://github.com/deepmap/oapi-codegen) tool for generating REST clients from OpenAPI specs.

The one fix is just a typo.  The other fixes are to the enum vals prefixed with an underscore.  The leading underscore causes the code gen to generate invalid code.  I'm sure there's a reason to have done this, but not sure why or if it can be modified in the Go spec file?