### PR TITLE
com.google.gson.GsonBuilder.create() can reverse its list

### DIFF
--- a/SampleCode/RestApi/Java/build.gradle
+++ b/SampleCode/RestApi/Java/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     compile 'io.swagger.core.v3:swagger-annotations:2.0.0'
     compile 'com.squareup.okhttp:okhttp:2.7.5'
     compile 'com.squareup.okhttp:logging-interceptor:2.7.5'
-    compile 'com.google.code.gson:gson:2.8.1'
+    compile 'com.google.code.gson:gson:2.8.3'
     compile 'io.gsonfire:gson-fire:1.8.3'
     testCompile 'junit:junit:4.12'
 }

--- a/SampleCode/RestApi/Java/pom.xml
+++ b/SampleCode/RestApi/Java/pom.xml
@@ -228,7 +228,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>2.0.0</swagger-core-version>
     <okhttp-version>2.7.5</okhttp-version>
-    <gson-version>2.8.1</gson-version>
+    <gson-version>2.8.3</gson-version>
     <gson-fire-version>1.8.3</gson-fire-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <junit-version>4.13.1</junit-version>


### PR DESCRIPTION
Calling GsonBuilder.create() multiple times results in the builder's underlying hierarchy factory list being reversed.
This bug is reported to GSon:https://github.com/google/gson/pull/1141

It is fixed in 2.8.3. I have checked that the new version does not break the API calls. 